### PR TITLE
Replace git:// with https:// for GitHub repos

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -14,7 +14,7 @@ pybullet = "*"
 [package.source]
 reference = "5f082287135b41e33cf01aa21a38572e8152ba1a"
 type = "git"
-url = "git://github.com/breuleux/pytorch-a2c-ppo-acktr-gail"
+url = "https://github.com/breuleux/pytorch-a2c-ppo-acktr-gail"
 
 [[package]]
 category = "main"
@@ -36,7 +36,7 @@ version = "0.1"
 [package.source]
 reference = "7f313e9ed3ce2f15bc68b4c47abfd32e04061524"
 type = "git"
-url = "git://github.com/breuleux/apex"
+url = "https://github.com/breuleux/apex"
 
 [[package]]
 category = "main"
@@ -69,7 +69,7 @@ torch = ">=0.4.1"
 [package.source]
 reference = "990627accce880a41e18503769e7bfb060582965"
 type = "git"
-url = "git://github.com/breuleux/babyai"
+url = "https://github.com/breuleux/babyai"
 
 [[package]]
 category = "main"
@@ -96,7 +96,7 @@ test = ["atari-py", "filelock", "matplotlib", "pandas", "pytest", "pytest-forked
 [package.source]
 reference = "50bdfc5730c58082df57f37f54702295187546d8"
 type = "git"
-url = "git://github.com/breuleux/baselines"
+url = "https://github.com/breuleux/baselines"
 
 [[package]]
 category = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ milarun = 'milarun.cli:main'
 [tool.poetry.dependencies]
 python = "^3.6"
 Cython = "^0.29.19"
-a2c-ppo-acktr = {git = "git://github.com/breuleux/pytorch-a2c-ppo-acktr-gail", branch = "milatweak"}
-apex = {git = "git://github.com/breuleux/apex", branch = "milatweak"}
-babyai = {git = "git://github.com/breuleux/babyai", branch = "master"}
-baselines = {git = "git://github.com/breuleux/baselines", branch = "milatweak"}
+a2c-ppo-acktr = {git = "https://github.com/breuleux/pytorch-a2c-ppo-acktr-gail", branch = "milatweak"}
+apex = {git = "https://github.com/breuleux/apex", branch = "milatweak"}
+babyai = {git = "https://github.com/breuleux/babyai", branch = "master"}
+baselines = {git = "https://github.com/breuleux/baselines", branch = "milatweak"}
 blessed = "^1.17.5"
 coleo = "^0.1.5"
 gitpython = "^3.1.2"


### PR DESCRIPTION
GitHub is making some protocol security changes and plan to turn off the
unencrypted Git protocol [1]. Use HTTPS instead.

[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/

See: GEN-1475