### PR TITLE
Filter missing timings

### DIFF
--- a/milabench/instruments.py
+++ b/milabench/instruments.py
@@ -175,6 +175,7 @@ def loading_rate(ov):
         (
             ov.probe("typ.next(!$x:@enter, #value as batch, !!$y:@exit)")
             .wmap(_timing)
+            .filter(lambda xs: xs is not None)
             .average(scan=5)
             .throttle(1)
             .map(lambda x: {"loading_rate": x, "units": "items/s"})


### PR DESCRIPTION
Why:

Sometimes the `loader` stream has no batch data in its results. When
this happens the accumulation of the stream fails.

How:

Add filter on data points for Nones.