### PR TITLE
Make sure constraints is always initialized to None

### DIFF
--- a/milabench/pack.py
+++ b/milabench/pack.py
@@ -34,7 +34,7 @@ class BasePackage:
     def __init__(self, config):
         self.config = config
         self.pack_path = XPath(config["definition"])
-
+        self.constraints = None
         self.dirs = NS(**{name: XPath(d) for name, d in config["dirs"].items()})
 
         reuse = True


### PR DESCRIPTION
the constraints attribute can be missing

```
running setup for /home/newton/work/milabench/runs/code/torchbench/torchbenchmark/models/BERT_pytorch...OK
Traceback (most recent call last):
  File "/home/newton/miniconda3/bin/milabench", line 8, in <module>
    sys.exit(main())
  File "/home/newton/work/milabench/milabench/cli.py", line 23, in main
    run_cli(Main)
  File "/home/newton/miniconda3/lib/python3.9/site-packages/coleo/cli.py", line 628, in run_cli
    return call(opts=opts, args=args)
  File "/home/newton/miniconda3/lib/python3.9/site-packages/coleo/cli.py", line 587, in thunk
    result = fn(*args)
  File "/home/newton/work/milabench/milabench/cli.py", line 223, in install
    mp.do_install(dash=simple_dash, force=force, sync=sync)
  File "/home/newton/work/milabench/milabench/multi.py", line 88, in do_install
    pack.checked_install(force=force, sync=sync)
  File "/home/newton/work/milabench/milabench/pack.py", line 98, in checked_install
    self.install_milabench()
  File "/home/newton/work/milabench/milabench/pack.py", line 139, in install_milabench
    self.pip_install("pip", "-U")
  File "/home/newton/work/milabench/milabench/pack.py", line 161, in pip_install
    if self.constraints:
AttributeError: 'TorchBenchmarkPack' object has no attribute 'constraints'

``