### PR TITLE
Remove ROCm Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,8 +30,6 @@ jobs:
         include:
           - arch: cuda
             config: standard-cuda.yaml
-          - arch: rocm
-            config: standard-rocm.yaml
     
     permissions:
       contents: read


### PR DESCRIPTION
Remove the docker images pending proper testing done on rocm.
We do not want people to try the image if they are broken