### PR TITLE
Remove problematic and irrelevant benchmarks, add timeout

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -1,6 +1,8 @@
 defaults: &defaults
   install_variant: "{arch}"
 
+  max_duration: 600
+
   voir:
     options:
       skip: 1

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -24,18 +24,6 @@ torchvision: &torchvision
   definition: ../benchmarks/torchvision
 
 
-sb3: &sb3
-    <<<: *defaults
-
-    group: sb3
-
-    plan:
-      method: njobs
-      n: 1
-
-    definition: ../benchmarks/stable_baselines3
-
-
 hf: &hf
   <<<: *defaults
 
@@ -82,22 +70,6 @@ benchmarks:
 
     argv:
       --model: resnet50
-
-  squeezenet1_1:
-    <<<: *torchvision
-    tags:
-      - convnet
-
-    argv:
-      --model: squeezenet1_1
-
-  efficientnet_b0:
-    <<<: *torchvision
-    tags:
-      - convnet
-
-    argv:
-      --model: efficientnet_b0
 
   efficientnet_b4:
     <<<: *torchvision
@@ -172,47 +144,3 @@ benchmarks:
       --strategy: "dp"
       --precision: 32
       --batch_size: 2048
-
-  vit_l_32:
-    <<<: *lightning
-    tags:
-      - convnet
-    argv:
-      --backbone: "vit_l_32"  # (larger model)
-      --strategy: "fsdp"  # Fully-Sharded Data-Parallel
-      --precision: 32
-
-  ppo:
-    <<<: *sb3
-    tags:
-      - rl
-
-    argv:
-      --algo: ppo
-      --env: HalfCheetahBulletEnv-v0
-      -n: '-1'
-      --num-threads: '-1'
-      --seed: '0'
-      --vec-env: subproc
-      --device: auto
-      --: [-params, n_envs:16, n_steps:512, n_epochs:20, n_timesteps:50000]
-
-  td3:
-    <<<: *sb3
-    tags:
-      - rl
-
-    argv:
-      --algo: td3
-      --env: HalfCheetahBulletEnv-v0 # Default: CartPole-v1
-      --n-eval-envs: '1'
-      --n-timesteps: '50000' # Default: '-1'
-      --num-threads: '-1'
-      --log-interval: '-1'
-      --eval-episodes: '5'
-      --save-freq: '-1'
-      --seed: '0' # Default: -1
-      --vec-env: subproc # Default: dummy
-      --device: auto
-      --n-trials: '10' # Default: 500
-      --n-jobs: '1'

--- a/config/others.yaml
+++ b/config/others.yaml
@@ -1,0 +1,88 @@
+defaults: &defaults
+  install_variant: "{arch}"
+
+  voir:
+    options:
+      stop: 60
+      interval: "1s"
+
+
+lightning: &lightning
+  <<<: *defaults
+
+  group: lightning
+  install_group: torch
+
+  plan:
+    method: njobs
+    n: 1
+
+  definition: ../benchmarks/pytorch-lightning
+
+  argv:
+    --gpus: -1
+    --max_epochs: 1
+    --max_steps: 100
+    --limit_val_batches: 100
+    --devices: -1
+    --enable_progress_bar: "False"
+    --accelerator: "auto"
+    --enable_checkpointing: "False"
+
+
+sb3: &sb3
+    <<<: *defaults
+
+    group: sb3
+
+    plan:
+      method: njobs
+      n: 1
+
+    definition: ../benchmarks/stable_baselines3
+
+
+benchmarks:
+  vit_l_32:
+    <<<: *lightning
+    tags:
+      - convnet
+    argv:
+      --backbone: "vit_l_32"  # (larger model)
+      --strategy: "fsdp"  # Fully-Sharded Data-Parallel
+      --precision: 32
+
+  ppo:
+    <<<: *sb3
+    tags:
+      - rl
+
+    argv:
+      --algo: ppo
+      --env: HalfCheetahBulletEnv-v0
+      -n: '-1'
+      --num-threads: '-1'
+      --seed: '0'
+      --vec-env: subproc
+      --device: auto
+      --: [-params, n_envs:16, n_steps:512, n_epochs:20, n_timesteps:50000]
+
+  td3:
+    <<<: *sb3
+    tags:
+      - rl
+
+    argv:
+      --algo: td3
+      --env: HalfCheetahBulletEnv-v0 # Default: CartPole-v1
+      --n-eval-envs: '1'
+      --n-timesteps: '50000' # Default: '-1'
+      --num-threads: '-1'
+      --log-interval: '-1'
+      --eval-episodes: '5'
+      --save-freq: '-1'
+      --seed: '0' # Default: -1
+      --vec-env: subproc # Default: dummy
+      --device: auto
+      --n-trials: '10' # Default: 500
+      --n-jobs: '1'

--- a/config/standard.yaml
+++ b/config/standard.yaml
@@ -23,18 +23,6 @@ torchvision: &torchvision
   definition: ../benchmarks/torchvision
 
 
-sb3: &sb3
-    <<<: *defaults
-
-    group: sb3
-
-    plan:
-      method: njobs
-      n: 1
-
-    definition: ../benchmarks/stable_baselines3
-
-
 hf: &hf
   <<<: *defaults
 
@@ -81,22 +69,6 @@ benchmarks:
 
     argv:
       --model: resnet50
-
-  squeezenet1_1:
-    <<<: *torchvision
-    tags:
-      - convnet
-
-    argv:
-      --model: squeezenet1_1
-
-  efficientnet_b0:
-    <<<: *torchvision
-    tags:
-      - convnet
-
-    argv:
-      --model: efficientnet_b0
 
   efficientnet_b4:
     <<<: *torchvision
@@ -163,47 +135,3 @@ benchmarks:
       --strategy: "dp"
       --precision: 32
       --batch_size: 2048
-
-  vit_l_32:
-    <<<: *lightning
-    tags:
-      - convnet
-    argv:
-      --backbone: "vit_l_32"  # (larger model)
-      --strategy: "fsdp"  # Fully-Sharded Data-Parallel
-      --precision: 32
-
-  ppo:
-    <<<: *sb3
-    tags:
-      - rl
-
-    argv:
-      --algo: ppo
-      --env: HalfCheetahBulletEnv-v0
-      -n: '-1'
-      --num-threads: '-1'
-      --seed: '0'
-      --vec-env: subproc
-      --device: auto
-      --: [-params, n_envs:16, n_steps:512, n_epochs:20, n_timesteps:50000]
-
-  td3:
-    <<<: *sb3
-    tags:
-      - rl
-
-    argv:
-      --algo: td3
-      --env: HalfCheetahBulletEnv-v0 # Default: CartPole-v1
-      --n-eval-envs: '1'
-      --n-timesteps: '50000' # Default: '-1'
-      --num-threads: '-1'
-      --log-interval: '-1'
-      --eval-episodes: '5'
-      --save-freq: '-1'
-      --seed: '0' # Default: -1
-      --vec-env: subproc # Default: dummy
-      --device: auto
-      --n-trials: '10' # Default: 500
-      --n-jobs: '1'

--- a/config/standard.yaml
+++ b/config/standard.yaml
@@ -1,6 +1,8 @@
 defaults: &defaults
   install_variant: "{arch}"
 
+  max_duration: 600
+
   voir:
     options:
       stop: 60

--- a/milabench/alt_async.py
+++ b/milabench/alt_async.py
@@ -158,10 +158,12 @@ def feedback_runner(gen):
 
 
 @feedback_runner
-def run(argv, setsid=None, info={}, **kwargs):
+def run(argv, setsid=None, info={}, process_accumulator=None, **kwargs):
     if setsid:
         kwargs["preexec_fn"] = os.setsid
     mx = voir_run(argv, info=info, **kwargs, timeout=0)
+    if process_accumulator is not None:
+        process_accumulator.extend(mx.processes)
     if setsid:
         for proc in mx.processes:
             proc.did_setsid = True

--- a/milabench/multi.py
+++ b/milabench/multi.py
@@ -61,6 +61,7 @@ class MultiPackage:
 
     async def do_install(self):
         for pack in self.packs.values():
+            pack.phase = "install"
             try:
                 await pack.checked_install()
             except Exception as exc:
@@ -68,6 +69,7 @@ class MultiPackage:
 
     async def do_prepare(self):
         for pack in self.packs.values():
+            pack.phase = "prepare"
             try:
                 await pack.prepare()
             except Exception as exc:
@@ -97,6 +99,7 @@ class MultiPackage:
                             run["tag"].append(f"R{index}")
                         run_pack = pack.copy(run)
                         await run_pack.send(event="config", data=run)
+                        run_pack.phase = "run"
                         coroutines.append(run_pack.run())
 
                         asyncio.create_task(
@@ -113,6 +116,7 @@ class MultiPackage:
     async def do_pin(self, pip_compile_args, constraints: list = tuple()):
         groups = defaultdict(dict)
         for pack in self.packs.values():
+            pack.phase = "pin"
             igrp = pack.config["install_group"]
             base_reqs = pack.requirements_map().keys()
             groups[igrp].update({req: pack for req in base_reqs})

--- a/milabench/pack.py
+++ b/milabench/pack.py
@@ -353,7 +353,7 @@ class Package(BasePackage):
             the manifest's contents to ``self.dirs.code``, installing
             milabench in the venv, and then calling this method.
         """
-        self.phase = "install"
+        assert self.phase == "install"
         for reqs in self.requirements_files(self.config.get("install_variant", None)):
             if reqs.exists():
                 await self.pip_install("-r", reqs)
@@ -377,7 +377,7 @@ class Package(BasePackage):
         """
         if self.config.get("install_variant", None) == "unpinned":
             raise Exception("Cannot pin the 'unpinned' variant.")
-        self.phase = "pin"
+        assert self.phase == "pin"
         for base_reqs, reqs in self.requirements_map().items():
             if not base_reqs.exists():
                 raise FileNotFoundError(
@@ -431,7 +431,7 @@ class Package(BasePackage):
 
         The default value of ``self.prepare_script`` is ``"prepare.py"``.
         """
-        self.phase = "prepare"
+        assert self.phase == "prepare"
         if self.prepare_script is not None:
             prep = self.dirs.code / self.prepare_script
             if prep.exists():
@@ -457,7 +457,7 @@ class Package(BasePackage):
             voirargs: A list of arguments to ``voir``.
             env: Environment variables to set for the process.
         """
-        self.phase = "run"
+        assert self.phase == "run"
         main = self.dirs.code / self.main_script
         if not main.exists():
             raise FileNotFoundError(

--- a/milabench/pack.py
+++ b/milabench/pack.py
@@ -88,6 +88,7 @@ class BasePackage:
         self.core = core
         self.config = config
         self.phase = None
+        self.processes = []
 
     def copy(self, config):
         return type(self)(config=merge(self.config, config))
@@ -201,6 +202,7 @@ class BasePackage:
             env=self.full_env(env) if not external else {**os.environ, **env},
             constructor=BenchLogEntry,
             cwd=cwd,
+            process_accumulator=self.processes,
         )
 
     async def python(self, *args, **kwargs):


### PR DESCRIPTION
* The following benchmarks are REMOVED from standard and ci:
  * `ppo` and `sd3`: they do not use the GPU enough, and they have also caused many problems in the past, especially ppo
  * `squeezenet1_1`: too small
  * `efficientnet_b0`: too small (also crashes on ROCm, but that wasn't the reason we were removing it)
  * `vit_l_32`: currently causes instability in any tests that come after it (more precisely: they hang). It may be an issue with milabench not cleaning up all child processes properly (to investigate; we may also be able to recover it from the timm suite).

Additionally, a 600 seconds timeout is set on each benchmark. A benchmark will be forcibly terminated if is exceeds that time limit. It is possible to customize the timeout of a per-benchmark basis.
