### PR TITLE
Slim down docker images

### DIFF
--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -4,6 +4,11 @@ FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04 AS init
 ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
 RUN ln /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.11.8.89 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so
 
+RUN apt-get update &&\
+    apt-get install -y git &&\
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
+
 # Arguments
 # ---------
 

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -1,12 +1,16 @@
 FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
+# CUDA-11.8 Fix
+ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
+RUN ln /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.11.8.89 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so
+
 # Arguments
 # ---------
 
 ARG ARCH=cuda
 ENV MILABENCH_GPU_ARCH=$ARCH
 
-ARG CONFIG=standard-8G.yaml
+ARG CONFIG=standard.yaml
 ENV MILABENCH_CONFIG_NAME=$CONFIG
 
 
@@ -30,13 +34,18 @@ COPY . /milabench/milabench/
 # Install Dependencies
 # --------------------
 
-#     curl | wget: used to download anaconda
+#            curl: used to download anaconda and rust
 #             git: used by milabench
 #           rustc: used by BERT models inside https://pypi.org/project/tokenizers/
 # build-essential: for rust
 #          libgl1: learn to paint bench
 #    libglib2.0-0: learn to paint bench
-RUN apt update && apt install -y wget git build-essential curl libgl1 libglib2.0-0
+
+RUN apt-get update &&\
+    apt-get install -y git build-essential curl libgl1 libglib2.0-0 &&\
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
+
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -44,10 +53,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # --------------
 
 # Install anaconda because milabench will need it later anyway
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p $CONDA_PATH
-
-RUN rm ~/miniconda.sh
+RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh -o ~/miniconda.sh &&\
+    /bin/bash ~/miniconda.sh -b -p $CONDA_PATH &&\
+    rm ~/miniconda.sh
 ENV PATH=$CONDA_PATH/bin:$PATH
 
 
@@ -57,7 +65,8 @@ ENV PATH=$CONDA_PATH/bin:$PATH
 RUN python -m pip install -U pip            &&\
     python -m pip install -U setuptools     &&\
     python -m pip install -U poetry         &&\
-    python -m pip install -e /milabench/milabench/
+    python -m pip install -e /milabench/milabench/ &&\
+    python -m pip cache purge
 
 # Prepare bench
 # -------------
@@ -66,15 +75,8 @@ RUN python -m pip install -U pip            &&\
 ENV PIP_DEFAULT_TIMEOUT=800
 
 RUN milabench install --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS &&\
-    milabench prepare --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS
+    milabench prepare --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS &&\
+    python -m pip cache purge
 
 
-# CUDA-11.8 Fix
-ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
-RUN ln /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.11.8.89 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so
-
-
-# Cleanup
-# Remove PIP cache
-# Remove APT unused packages
 # CMD milabench

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04 AS prepare
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04 AS init
 
 # CUDA-11.8 Fix
 ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
@@ -30,6 +30,8 @@ ENV CONDA_PATH=/opt/anaconda
 WORKDIR /milabench
 COPY . /milabench/milabench/
 
+
+FROM init AS install
 
 # Install Dependencies
 # --------------------
@@ -69,6 +71,8 @@ RUN python -m pip install -U pip            &&\
 # Prepare bench
 # -------------
 
+FROM install AS prepare
+
 # pip times out often when downloading pytorch
 ENV PIP_DEFAULT_TIMEOUT=800
 
@@ -76,24 +80,9 @@ RUN milabench install --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABEN
     milabench prepare --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS
 
 
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+FROM init
 
-# CUDA-11.8 Fix
-ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
-RUN ln /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.11.8.89 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so
-
-COPY --from=prepare /opt/anaconda /opt/anaconda
-
-WORKDIR /milabench
-COPY . /milabench/milabench
-
+COPY --from=install /opt/anaconda /opt/anaconda
 COPY --from=prepare /milabench/envs /milabench/envs
-
-ENV MILABENCH_GPU_ARCH=$ARCH
-ENV MILABENCH_CONFIG_NAME=$CONFIG
-ENV MILABENCH_CONFIG=/milabench/milabench/config/$MILABENCH_CONFIG_NAME
-ENV MILABENCH_BASE=/milabench/envs
-ENV MILABENCH_OUTPUT=/milabench/results/
-ENV MILABENCH_ARGS=""
 
 CMD ["milabench", "run"]

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04 AS prepare
 
 # CUDA-11.8 Fix
 ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
@@ -54,8 +54,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install anaconda because milabench will need it later anyway
 RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh -o ~/miniconda.sh &&\
-    /bin/bash ~/miniconda.sh -b -p $CONDA_PATH &&\
-    rm ~/miniconda.sh
+    /bin/bash ~/miniconda.sh -b -p $CONDA_PATH
 ENV PATH=$CONDA_PATH/bin:$PATH
 
 
@@ -65,8 +64,7 @@ ENV PATH=$CONDA_PATH/bin:$PATH
 RUN python -m pip install -U pip            &&\
     python -m pip install -U setuptools     &&\
     python -m pip install -U poetry         &&\
-    python -m pip install -e /milabench/milabench/ &&\
-    python -m pip cache purge
+    python -m pip install -e /milabench/milabench/
 
 # Prepare bench
 # -------------
@@ -75,8 +73,27 @@ RUN python -m pip install -U pip            &&\
 ENV PIP_DEFAULT_TIMEOUT=800
 
 RUN milabench install --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS &&\
-    milabench prepare --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS &&\
-    python -m pip cache purge
+    milabench prepare --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS
 
 
-# CMD milabench
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+# CUDA-11.8 Fix
+ENV LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib/:$LD_LIBRARY_PATH"
+RUN ln /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.11.8.89 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so
+
+COPY --from=prepare /opt/anaconda /opt/anaconda
+
+WORKDIR /milabench
+COPY . /milabench/milabench
+
+COPY --from=prepare /milabench/envs /milabench/envs
+
+ENV MILABENCH_GPU_ARCH=$ARCH
+ENV MILABENCH_CONFIG_NAME=$CONFIG
+ENV MILABENCH_CONFIG=/milabench/milabench/config/$MILABENCH_CONFIG_NAME
+ENV MILABENCH_BASE=/milabench/envs
+ENV MILABENCH_OUTPUT=/milabench/results/
+ENV MILABENCH_ARGS=""
+
+CMD ["milabench", "run"]

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -64,10 +64,11 @@ RUN python -m pip install -U pip            &&\
     python -m pip install -U poetry         &&\
     python -m pip install -e /milabench/milabench/
 
-# Prepare bench
-# -------------
 
 FROM install AS prepare
+
+# Prepare bench
+# -------------
 
 # pip times out often when downloading pytorch
 ENV PIP_DEFAULT_TIMEOUT=800

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -40,13 +40,9 @@ FROM init AS install
 #             git: used by milabench
 #           rustc: used by BERT models inside https://pypi.org/project/tokenizers/
 # build-essential: for rust
-#          libgl1: learn to paint bench
-#    libglib2.0-0: learn to paint bench
 
 RUN apt-get update &&\
-    apt-get install -y git build-essential curl libgl1 libglib2.0-0 &&\
-    apt-get clean &&\
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y git build-essential curl
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -80,6 +80,7 @@ RUN milabench install --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABEN
 FROM init
 
 COPY --from=install /opt/anaconda /opt/anaconda
+ENV PATH=$CONDA_PATH/bin:$PATH
 COPY --from=prepare /milabench/envs /milabench/envs
 
 CMD ["milabench", "run"]

--- a/docker/Dockerfile-rocm
+++ b/docker/Dockerfile-rocm
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS init
 
 # Arguments
 # ---------
@@ -27,14 +27,19 @@ WORKDIR /milabench
 COPY . /milabench/milabench/
 
 
+FROM init AS install
+
 # Install Dependencies
 # --------------------
 
-#     curl | wget: used to download anaconda
+#            curl: used to download anaconda
 #             git: used by milabench
 #           rustc: used by BERT models inside https://pypi.org/project/tokenizers/
 # build-essential: for rust
-RUN apt update && apt install -y wget git build-essential curl
+
+RUN apt-get update &&\
+    apt-get install -y git build-essential curl
+
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -42,10 +47,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # --------------
 
 # Install anaconda because milabench will need it later anyway
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py39_23.1.0-1-Linux-x86_64.sh -o ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p $CONDA_PATH
-
-RUN rm ~/miniconda.sh
 ENV PATH=$CONDA_PATH/bin:$PATH
 
 
@@ -57,6 +60,9 @@ RUN python -m pip install -U pip            &&\
     python -m pip install -U poetry         &&\
     python -m pip install -e /milabench/milabench/
 
+
+FROM install AS prepare
+
 # Prepare bench
 # -------------
 
@@ -67,7 +73,9 @@ RUN milabench install --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABEN
     milabench prepare --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABENCH_ARGS
 
 
-# Cleanup
-# Remove PIP cache
-# Remove APT unused packages
-# CMD milabench
+FROM init
+
+COPY --from=install /opt/anaconda /opt/anaconda
+COPY --from=prepare /milabench/envs /milabench/envs
+
+CMD ["milabench", "run"]

--- a/docker/Dockerfile-rocm
+++ b/docker/Dockerfile-rocm
@@ -1,5 +1,10 @@
 FROM ubuntu:22.04 AS init
 
+RUN apt-get update &&\
+    apt-get install -y git &&\
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
+
 # Arguments
 # ---------
 

--- a/docker/Dockerfile-rocm
+++ b/docker/Dockerfile-rocm
@@ -34,9 +34,7 @@ COPY . /milabench/milabench/
 #             git: used by milabench
 #           rustc: used by BERT models inside https://pypi.org/project/tokenizers/
 # build-essential: for rust
-#          libgl1: learn to paint bench
-#    libglib2.0-0: learn to paint bench
-RUN apt update && apt install -y wget git build-essential curl libgl1 libglib2.0-0
+RUN apt update && apt install -y wget git build-essential curl
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/docker/Dockerfile-rocm
+++ b/docker/Dockerfile-rocm
@@ -76,6 +76,7 @@ RUN milabench install --config $MILABENCH_CONFIG --base $MILABENCH_BASE $MILABEN
 FROM init
 
 COPY --from=install /opt/anaconda /opt/anaconda
+ENV PATH=$CONDA_PATH/bin:$PATH
 COPY --from=prepare /milabench/envs /milabench/envs
 
 CMD ["milabench", "run"]

--- a/weights/standard.json
+++ b/weights/standard.json
@@ -14,7 +14,6 @@
     "speech_transformer": {"weight": 1},
     "super_slomo": {"weight": 1},
     "stargan": {"weight": 1},
-    "learning_to_paint": {"weight": 1},
     "ppo": {"weight": 1},
     "resnet152": {"weight": 1}
 }


### PR DESCRIPTION
This was lightly tested (the cuda version only) and appears to work fine.

The size of the cuda image goes from 16.1GB to 11.7GB in the commit I tested with.