### PR TITLE
Misc improvements

### DIFF
--- a/benchmarks/accelerate_opt/benchfile.py
+++ b/benchmarks/accelerate_opt/benchfile.py
@@ -11,19 +11,21 @@ class AccelerateBenchmark(Package):
 
     async def prepare(self):
         self.phase = "prepare"
+        nproc = len(self.config.get("devices", []))
         await self.execute(
             "accelerate",
             "launch",
             "--mixed_precision=fp16",
             "--num_machines=1",
             "--dynamo_backend=no",
-            "--num_processes=8",
+            f"--num_processes={nproc}",
             str(self.dirs.code / "main.py"),
             env={"MILABENCH_PREPARE_ONLY": "1"},
         )
 
     async def run(self):
         self.phase = "run"
+        nproc = len(self.config.get("devices", []))
         await self.execute(
             "accelerate",
             "launch",
@@ -37,7 +39,8 @@ class AccelerateBenchmark(Package):
             f"--num_cpu_threads_per_process={self.config['cpus_per_gpu']}",
             f"--main_process_ip={self.config['manager_addr']}",
             f"--main_process_port={self.config['manager_port']}",
-            f"--num_processes={self.config['num_processes']}",
+            # f"--num_processes={self.config['num_processes']}",
+            f"--num_processes={nproc}",
             str(self.dirs.code / "main.py"),
             setsid=True,
             use_stdout=True,

--- a/benchmarks/timm/prepare.py
+++ b/benchmarks/timm/prepare.py
@@ -4,11 +4,12 @@ import multiprocessing
 import os
 from pathlib import Path
 
-from torchvision.datasets import FakeData
 from tqdm import tqdm
 
 
 def write(args):
+    from torchvision.datasets import FakeData
+
     image_size, offset, count, outdir = args
     dataset = FakeData(
         size=count, image_size=image_size, num_classes=1000, random_offset=offset
@@ -54,5 +55,5 @@ if __name__ == "__main__":
     data_directory = os.environ["MILABENCH_DIR_DATA"]
     dest = os.path.join(data_directory, "FakeImageNet")
     print(f"Generating fake data into {dest}...")
-    generate_sets(dest, {"train": 1000, "val": 10, "test": 10}, (3, 512, 512))
+    generate_sets(dest, {"train": 4096, "val": 16, "test": 16}, (3, 384, 384))
     print("Done!")

--- a/benchmarks/torchvision/main.py
+++ b/benchmarks/torchvision/main.py
@@ -108,6 +108,12 @@ def main():
         metavar="S",
         help="random seed (default: 1234)",
     )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=8,
+        help="number of workers for data loading",
+    )
     parser.add_argument("--data", type=str, help="data directory")
     parser.add_argument(
         "--synthetic-data", action="store_true", help="whether to use synthetic data"
@@ -168,7 +174,7 @@ def main():
             train,
             batch_size=args.batch_size,
             shuffle=True,
-            num_workers=1,
+            num_workers=args.num_workers,
         )
     else:
         train_loader = SyntheticData(

--- a/benchmarks/torchvision/prepare.py
+++ b/benchmarks/torchvision/prepare.py
@@ -4,11 +4,12 @@ import multiprocessing
 import os
 from pathlib import Path
 
-from torchvision.datasets import FakeData
 from tqdm import tqdm
 
 
 def write(args):
+    from torchvision.datasets import FakeData
+
     image_size, offset, count, outdir = args
     dataset = FakeData(
         size=count, image_size=image_size, num_classes=1000, random_offset=offset
@@ -54,5 +55,5 @@ if __name__ == "__main__":
     data_directory = os.environ["MILABENCH_DIR_DATA"]
     dest = os.path.join(data_directory, "FakeImageNet")
     print(f"Generating fake data into {dest}...")
-    generate_sets(dest, {"train": 1000, "val": 10, "test": 10}, (3, 512, 512))
+    generate_sets(dest, {"train": 4096, "val": 16, "test": 16}, (3, 384, 384))
     print("Done!")

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -172,7 +172,7 @@ vit_l_32:
     n: 1
   argv:
     --model: vit_large_patch32_224
-    --batch-size: 512
+    --batch-size: 256
 
 focalnet:
   inherits: _timm

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -16,6 +16,8 @@ _torchvision:
   argv:
     --with-amp: true
     --lr: 0.01
+    --no-stdout: true
+    --epochs: 50
 
 _hf:
   inherits: _defaults
@@ -53,6 +55,7 @@ resnet50:
   
   argv:
     --model: resnet50
+    --batch-size: 64
 
 efficientnet_b4:
   inherits: _torchvision
@@ -64,6 +67,7 @@ efficientnet_b4:
 
   argv:
     --model: efficientnet_b4
+    --batch-size: 256
 
 efficientnet_b7:
   inherits: _torchvision
@@ -73,6 +77,7 @@ efficientnet_b7:
     - convnet
   argv:
     --model: efficientnet_b7
+    --batch-size: 128
 
 convnext_large:
   inherits: _torchvision
@@ -82,6 +87,7 @@ convnext_large:
     - convnet
   argv:
     --model: convnext_large
+    --batch-size: 128
 
 regnet_y_128gf:
   inherits: _torchvision
@@ -93,6 +99,7 @@ regnet_y_128gf:
     - lstm
   argv:
     --model: regnet_y_128gf
+    --batch-size: 64
 
 bert:
   inherits: _hf
@@ -103,6 +110,7 @@ bert:
     - huggingface
   argv:
     --model: "Bert"
+    --batch-size: 32
 
 t5:
   inherits: _hf
@@ -113,6 +121,7 @@ t5:
     - huggingface
   argv:
     --model: "T5"
+    --batch-size: 16
 
 reformer:
   inherits: _hf
@@ -123,6 +132,7 @@ reformer:
     - huggingface
   argv:
     --model: "Reformer"
+    --batch-size: 64
 
 whisper:
   inherits: _hf
@@ -131,6 +141,7 @@ whisper:
     - huggingface
   argv:
     --model: "Whisper"
+    --batch-size: 64
 
 resnet152:
   inherits: _timm
@@ -146,6 +157,7 @@ resnet152:
     n: 1
   argv:
     --model: resnet152
+    --batch-size: 256
 
 vit_l_32:
   inherits: _timm
@@ -160,8 +172,20 @@ vit_l_32:
     n: 1
   argv:
     --model: vit_large_patch32_224
+    --batch-size: 512
 
-accelerate:
+focalnet:
+  inherits: _timm
+  tags:
+    - vision
+    - classification
+    - convnet
+  plan:
+    method: per_gpu
+  argv:
+    --model: focalnet_small_lrf
+
+opt-2.7b:
   inherits: _defaults
   tags:
     - nlp
@@ -191,18 +215,6 @@ accelerate:
   dataset_name: "wikitext"
   dataset_config_name: "wikitext-103-v1"
   validation_split_percentage: 5
-
-focalnet:
-  inherits: _timm
-  tags:
-    - vision
-    - classification
-    - convnet
-
-  plan:
-    method: per_gpu
-  argv:
-    --model: focalnet_small_lrf
 
 stargan:
   inherits: _defaults

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -203,7 +203,6 @@ opt-2.7b:
   # This is for single-node
   manager_addr: "127.0.0.1"
   manager_port: 10000
-  num_processes: 2
   cpus_per_gpu: 8
   # model_name: "facebook/opt-350m"
   model_name: "facebook/opt-2.7b"

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -31,6 +31,14 @@ t5:
   argv:
     --batch-size: 2
 
+reformer:
+  argv:
+    --batch-size: 16
+
+whisper:
+  argv:
+    --batch-size: 16
+
 resnet152:
   argv:
     --batch-size: 32
@@ -39,7 +47,7 @@ vit_l_32:
   argv:
     --batch-size: 32
 
-accelerate:
+opt-2.7b:
   model_name: "facebook/bart-base"
 
 focalnet:

--- a/config/standard.yaml
+++ b/config/standard.yaml
@@ -49,7 +49,7 @@ vit_l_32:
   enabled: true
   weight: 1.0
 
-accelerate:
+opt-2.7b:
   enabled: true
   weight: 1.0
 

--- a/milabench/cli.py
+++ b/milabench/cli.py
@@ -261,6 +261,8 @@ def run_sync(coro, terminal=True):
 
 class Main:
     def run():
+        """Run the benchmarks."""
+
         # Name of the run
         run_name: Option = None
 
@@ -326,6 +328,8 @@ class Main:
         return success
 
     def prepare():
+        """Prepare a benchmark: download datasets, weights etc."""
+
         mp = get_multipack(run_name="prepare.{time}")
 
         # On error show full stacktrace
@@ -344,6 +348,8 @@ class Main:
         )
 
     def install():
+        """Install the benchmarks' dependencies."""
+
         # Force install
         force: Option & bool = False
 
@@ -376,6 +382,8 @@ class Main:
         )
 
     def pin():
+        """Pin the benchmarks' dependencies."""
+
         # Extra args to pass to pip-compile
         # [nargs: --]
         pip_compile: Option = tuple()
@@ -421,6 +429,8 @@ class Main:
         )
 
     def dev():
+        """Create a shell in a benchmark's environment for development."""
+
         # The name of the benchmark to develop
         select: Option & str
 
@@ -439,6 +449,8 @@ class Main:
         )
 
     def summary():
+        """Produce a JSON summary of a previous run."""
+
         # Directory(ies) containing the run data
         # [positional: +]
         runs: Option = []
@@ -457,29 +469,30 @@ class Main:
             print(json.dumps(summary, indent=4))
 
     def compare():
-        """Compare all runs with each other
-        Parameters
-        ----------
-        folder: str
-            Folder where milabench results are stored
-        last: int
-            Number of runs to compare i.e 3 means the 3 latest runs only
-        metric: str
-            Metric to compare
-        stat: str
-            statistic name to compare
-        Examples
-        --------
-        >>> milabench compare results/ --last 3 --metric train_rate --stat median
-                                               |   rufidoko |   sokilupa
-                                               | 2023-02-23 | 2023-03-09
-        bench                |          metric |   16:16:31 |   16:02:53
-        ----------------------------------------------------------------
-        bert                 |      train_rate |     243.05 |     158.50
-        convnext_large       |      train_rate |     210.11 |     216.23
-        dlrm                 |      train_rate |  338294.94 |  294967.41
-        efficientnet_b0      |      train_rate |     223.56 |     223.48
-        """
+        """Compare all runs with each other."""
+
+        # Parameters
+        # ----------
+        # folder: str
+        #     Folder where milabench results are stored
+        # last: int
+        #     Number of runs to compare i.e 3 means the 3 latest runs only
+        # metric: str
+        #     Metric to compare
+        # stat: str
+        #     statistic name to compare
+        # Examples
+        # --------
+        # >>> milabench compare results/ --last 3 --metric train_rate --stat median
+        #                                        |   rufidoko |   sokilupa
+        #                                        | 2023-02-23 | 2023-03-09
+        # bench                |          metric |   16:16:31 |   16:02:53
+        # ----------------------------------------------------------------
+        # bert                 |      train_rate |     243.05 |     158.50
+        # convnext_large       |      train_rate |     210.11 |     216.23
+        # dlrm                 |      train_rate |  338294.94 |  294967.41
+        # efficientnet_b0      |      train_rate |     223.56 |     223.48
+
         # [positional: ?]
         folder: Option = None
 
@@ -504,24 +517,25 @@ class Main:
         compare(runs, last, metric, stat)
 
     def report():
-        """Generate a report aggregating all runs together into a final report
-        Examples
-        --------
-        >>> milabench report --runs results/
-        Source: /home/newton/work/milabench/milabench/../tests/results
-        =================
-        Benchmark results
-        =================
-                           n fail       perf   perf_adj   std%   sem%% peak_memory
-        bert               2    0     201.06     201.06  21.3%   8.7%          -1
-        convnext_large     2    0     198.62     198.62  19.7%   2.5%       29878
-        td3                2    0   23294.73   23294.73  13.6%   2.1%        2928
-        vit_l_32           2    1     548.09     274.04   7.8%   0.8%        9771
-        <BLANKLINE>
-        Errors
-        ------
-        1 errors, details in HTML report.
-        """
+        """Generate a report aggregating all runs together into a final report."""
+
+        # Examples
+        # --------
+        # >>> milabench report --runs results/
+        # Source: /home/newton/work/milabench/milabench/../tests/results
+        # =================
+        # Benchmark results
+        # =================
+        #                    n fail       perf   perf_adj   std%   sem%% peak_memory
+        # bert               2    0     201.06     201.06  21.3%   8.7%          -1
+        # convnext_large     2    0     198.62     198.62  19.7%   2.5%       29878
+        # td3                2    0   23294.73   23294.73  13.6%   2.1%        2928
+        # vit_l_32           2    1     548.09     274.04   7.8%   0.8%        9771
+        # <BLANKLINE>
+        # Errors
+        # ------
+        # 1 errors, details in HTML report.
+
         # Runs directory
         # [action: append]
         runs: Option = []
@@ -573,6 +587,8 @@ class Main:
             run_sync(pack.pip_install(*args))
 
     def container():
+        """Build a container image (might not work properly at the moment)."""
+
         # Configuration file
         # [positional]
         config_file: Option & str = None

--- a/milabench/compare.py
+++ b/milabench/compare.py
@@ -15,6 +15,8 @@ def fetch_runs(folder):
     runs = []
     for run in os.listdir(folder):
         pth = os.path.join(folder, run)
+        if not os.path.isdir(pth):
+            continue
         if "." in run:
             name, date = run.split(".", maxsplit=1)
             date = datetime.strptime(date, "%Y-%m-%d_%H:%M:%S.%f")

--- a/milabench/pack.py
+++ b/milabench/pack.py
@@ -102,7 +102,11 @@ class BasePackage:
 
     @property
     def logdir(self):
-        return self.dirs.runs / self.config["run_name"]
+        run_name = self.config["run_name"]
+        if run_name and run_name[0] in ("/", ".", "~"):
+            return XPath(run_name).expanduser().absolute()
+        else:
+            return self.dirs.runs / run_name
 
     def logfile(self, extension):
         return self.logdir / (".".join(self.config["tag"]) + f".{extension}")

--- a/milabench/summary.py
+++ b/milabench/summary.py
@@ -110,7 +110,9 @@ nans = {
 
 @error_guard(nans)
 def _metrics(xs):
-    xs = [x for x in xs if x is not None]
+    xs = sorted(x for x in xs if x is not None)
+    if len(xs) >= 5:
+        xs = xs[1:-1]  # Remove min and max
     if not xs:
         return nans
     percentiles = [0, 25, 50, 75, 100]

--- a/tests/test_summary/test_report.txt
+++ b/tests/test_summary/test_report.txt
@@ -3,4 +3,4 @@ Source: XXX
 Benchmark results
 =================
         fail n peak_memory       perf   perf_adj   sem%   std%
-benchio    0 4          -1    7931.91    7931.91   3.0%  18.2%
+benchio    0 4          -1    7979.82    7979.82   2.9%  17.2%

--- a/tests/test_summary/test_report_folder_does_average.txt
+++ b/tests/test_summary/test_report_folder_does_average.txt
@@ -3,4 +3,4 @@ Source: XXX
 Benchmark results
 =================
         fail n peak_memory       perf   perf_adj   sem%   std%
-benchio    0 6          -1    7843.01    7843.01   2.6%  18.9%
+benchio    0 6          -1    7878.45    7878.45   2.5%  18.0%


### PR DESCRIPTION
* Solves #103 
* `--run-name ./local/directory` should work
* Manually adjusted batch size for better GPU utilization
* Increase the size of FakeImageNet so that each GPU can get two batches in 8-GPU tests with the resnet152 and vit_l_32 benchmarks
* Rename the `accelerate` benchmark to `opt-2.7b` and auto-detect the number of processes.
* Stabilize summary statistics by removing min/max values.
* Add num_workers to torchvision tests so that they can run faster.