### PR TITLE
Fix instability in Whisper benchmark

### DIFF
--- a/benchmarks/huggingface/bench/__main__.py
+++ b/benchmarks/huggingface/bench/__main__.py
@@ -40,7 +40,9 @@ class Runner:
             repeat=100000,
             generators=generators[info.category](info),
         )
-        self.loader = DataLoader(self.data, batch_size=args.batch_size)
+        self.loader = DataLoader(
+            self.data, batch_size=args.batch_size, num_workers=args.num_workers
+        )
 
         self.amp_scaler = torch.cuda.amp.GradScaler(enabled=is_fp16_allowed(args))
         if is_fp16_allowed(args):
@@ -129,6 +131,12 @@ def parser():
         choices=["fp16", "fp32", "tf32", "tf32-fp16"],
         default="fp32",
         help="Precision configuration",
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=8,
+        help="number of workers for data loading",
     )
     # parser.add_argument(
     #     "--no-stdout",

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -30,6 +30,7 @@ _hf:
   install_group: torch
   argv:
     --precision: 'tf32-fp16'
+    --num-workers: 8
 
   plan:
     method: per_gpu


### PR DESCRIPTION
The Whisper benchmark yields unstable results depending on the number of GPUs that we are testing on because the num_workers argument is not provided for the DataLoader for each job, and the heuristics used cause interference. The result is that the number of samples per second gets lower per GPU as more GPUs are running at the same time. The fix is to add the argument and set it to a reasonable value.

Other HuggingFace tests could be affected by this change, but the particularity of Whisper is that the DataLoader does some heavy work, so resources put into it matter. This is not the case for the other models. I have observed no change in performance for the T5 benchmark for example.
