### PR TITLE
Make error validation work with python exception

### DIFF
--- a/milabench/_version.py
+++ b/milabench/_version.py
@@ -1,5 +1,5 @@
 """This file is generated, do not modify"""
 
-__tag__ = "v0.0.6-34-g908e561"
-__commit__ = "908e561737bfd8e57f5b4f47cf81ccd8d9e01887"
-__date__ = "2023-06-15 02:04:55 -0400"
+__tag__ = "v0.0.6-13-ga7dc7f2"
+__commit__ = "a7dc7f2f0bcf9858e4e7d4c8407b17730ad799ac"
+__date__ = "2023-06-20 14:27:39 -0400"

--- a/milabench/cli.py
+++ b/milabench/cli.py
@@ -264,6 +264,7 @@ def _read_reports(*runs):
                         data = [json.loads(line) for line in lines]
                     except Exception:
                         import traceback
+
                         print(f"Could not parse line inside {pth}\n\t- {line}")
                         traceback.print_exc()
                     else:

--- a/milabench/cli.py
+++ b/milabench/cli.py
@@ -411,7 +411,7 @@ class Main:
         mp = get_multipack(run_name="prepare.{time}")
 
         # On error show full stacktrace
-        fulltrace: Option & bool = False
+        shortrace: Option & bool = False
 
         return run_with_loggers(
             mp.do_prepare(),
@@ -420,7 +420,7 @@ class Main:
                 TextReporter("stdout"),
                 TextReporter("stderr"),
                 DataReporter(),
-                *validation_layers("error", short=not fulltrace),
+                *validation_layers("error", short=shortrace),
             ],
             mp=mp,
         )
@@ -432,7 +432,7 @@ class Main:
         force: Option & bool = False
 
         # On error show full stacktrace
-        fulltrace: Option & bool = False
+        shorttrace: Option & bool = False
 
         # Install variant
         variant: Option & str = None
@@ -454,7 +454,7 @@ class Main:
                 TextReporter("stdout"),
                 TextReporter("stderr"),
                 DataReporter(),
-                *validation_layers("error", short=not fulltrace),
+                *validation_layers("error", short=shorttrace),
             ],
             mp=mp,
         )

--- a/milabench/executors.py
+++ b/milabench/executors.py
@@ -30,7 +30,7 @@ async def force_terminate(pack, delay):
             destroy(proc)
 
 
-class Executor():
+class Executor:
     """Base class for an execution plan
 
     Will recursively go through its embedded `Executor` to build a command
@@ -43,11 +43,12 @@ class Executor():
                       commands calls
         **kwargs: kwargs to be passed to the `pack_or_exec.execute()`, if a
                   `BasePackage`
-                  
+
     Notes:
         All dynamic operations need to happen inside the argv/_argv methods.
         Those methods are guaranteed to be called with the final configuration.
     """
+
     def __init__(self, pack_or_exec: Executor | pack.BasePackage, **kwargs) -> None:
         if isinstance(pack_or_exec, Executor):
             self.exec = pack_or_exec
@@ -90,18 +91,17 @@ class Executor():
         raise NotImplemented()
 
     async def execute(self, timeout=False, timeout_delay=600, **kwargs):
-        """Execute all the commands and return the aggregated results
-        """
+        """Execute all the commands and return the aggregated results"""
         coro = []
 
         for pack, argv, _kwargs in self.commands():
             await pack.send(event="config", data=pack.config)
             await pack.send(event="meta", data=machine_metadata())
 
-            if hasattr(pack, 'override_run'):
+            if hasattr(pack, "override_run"):
                 # TODO: This is only to hack the CI and have the test passing
                 # using the old system. Remove override_run() and use `Executor`
-                # instead 
+                # instead
                 fut = pack.override_run()
             else:
                 pack.phase = "run"
@@ -156,15 +156,9 @@ class ListExecutor(Executor):
         executors: `Executor`s to be executed
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            *executors: Tuple[Executor],
-            **kwargs
-    ) -> None:
-        super().__init__(
-            executors[0],
-            **kwargs
-        )
+
+    def __init__(self, *executors: Tuple[Executor], **kwargs) -> None:
+        super().__init__(executors[0], **kwargs)
         self.executors = executors
 
     def commands(self) -> Generator[Tuple[pack.BasePackage, List, Dict], None, None]:
@@ -181,19 +175,14 @@ class CmdExecutor(SingleCmdExecutor):
         *cmd_argv: command line arguments list to execute
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            pack: pack.BasePackage,
-            *cmd_argv,
-            **kwargs
-    ) -> None:
+
+    def __init__(self, pack: pack.BasePackage, *cmd_argv, **kwargs) -> None:
         if isinstance(pack, Executor):
-            raise TypeError(f"{self.__class__.__name__} does not accept nested"
-                            f" {Executor.__name__}")
-        super().__init__(
-            pack,
-            **kwargs
-        )
+            raise TypeError(
+                f"{self.__class__.__name__} does not accept nested"
+                f" {Executor.__name__}"
+            )
+        super().__init__(pack, **kwargs)
         self.cmd_argv = cmd_argv
 
     def _argv(self, **_) -> List:
@@ -212,12 +201,8 @@ class PackExecutor(CmdExecutor):
                       file will be used instead of the `pack`'s main_script
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            pack: pack.Package,
-            *script_argv,
-            **kwargs
-    ) -> None:
+
+    def __init__(self, pack: pack.Package, *script_argv, **kwargs) -> None:
         script = script_argv[:1]
         if script and XPath(script[0]).exists():
             script = script[0]
@@ -250,12 +235,8 @@ class PackExecutor(CmdExecutor):
 
 class VoidExecutor(CmdExecutor):
     """Execute nothing"""
-    def __init__(
-            self,
-            pack: pack.BasePackage,
-            *argv,
-            **kwargs
-    ) -> None:
+
+    def __init__(self, pack: pack.BasePackage, *argv, **kwargs) -> None:
         super().__init__(pack, "true", *argv, **kwargs)
 
 
@@ -267,16 +248,9 @@ class WrapperExecutor(SingleCmdExecutor):
         *wrapper_argv: command line arguments list
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            executor: SingleCmdExecutor,
-            *wrapper_argv,
-            **kwargs
-    ) -> None:
-        super().__init__(
-            executor,
-            **kwargs
-        )
+
+    def __init__(self, executor: SingleCmdExecutor, *wrapper_argv, **kwargs) -> None:
+        super().__init__(executor, **kwargs)
         self.wrapper_argv = wrapper_argv
 
     def _argv(self, **kwargs) -> List:
@@ -293,12 +267,9 @@ class DockerRunExecutor(WrapperExecutor):
         *docker_argv: Docker command line arguments list
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
+
     def __init__(
-            self,
-            executor: SingleCmdExecutor,
-            image: str,
-            *docker_argv,
-            **kwargs
+        self, executor: SingleCmdExecutor, image: str, *docker_argv, **kwargs
     ) -> None:
         super().__init__(
             executor,
@@ -312,7 +283,7 @@ class DockerRunExecutor(WrapperExecutor):
             "--gpus",
             "all",
             *docker_argv,
-            **kwargs
+            **kwargs,
         )
         self.image = image
 
@@ -349,6 +320,7 @@ class SSHExecutor(WrapperExecutor):
              will be used to find the username
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
+
     def __init__(
         self,
         executor: SingleCmdExecutor,
@@ -364,7 +336,8 @@ class SSHExecutor(WrapperExecutor):
             "-oCheckHostIP=no",
             "-oStrictHostKeyChecking=no",
             *ssh_argv,
-            **kwargs)
+            **kwargs,
+        )
         self.host = host
         self.user = user
         self.key = key
@@ -420,17 +393,9 @@ class VoirExecutor(WrapperExecutor):
         *voir_argv: voir command line arguments list
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            executor: SingleCmdExecutor,
-            *voir_argv,
-            **kwargs
-    ) -> None:
-        super().__init__(
-            executor,
-            "voir",
-            **{"setsid":True, **kwargs}
-        )
+
+    def __init__(self, executor: SingleCmdExecutor, *voir_argv, **kwargs) -> None:
+        super().__init__(executor, "voir", **{"setsid": True, **kwargs})
         self.voir_argv = voir_argv
 
     def _argv(self, **kwargs) -> List:
@@ -460,9 +425,10 @@ class NJobs(ListExecutor):
 
     Arguments:
         executor: `Executor` to be executed
-        n: number of times `executor` should be executed 
+        n: number of times `executor` should be executed
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
+
     def __init__(self, executor: Executor, n: int, gpus: list = None, **kwargs) -> None:
         self.n = n
         if gpus is None:
@@ -490,19 +456,13 @@ class SequenceExecutor(ListExecutor):
         executors: `Executor`s to be executed
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            *executors: Tuple[Executor],
-            **kwargs
-    ) -> None:
-        super().__init__(
-            None,
-            **kwargs
-        )
+
+    def __init__(self, *executors: Tuple[Executor], **kwargs) -> None:
+        super().__init__(None, **kwargs)
         self.executors = executors
 
     async def execute(self, **kwargs):
-        results = [] 
+        results = []
         for executor in self.executors:
             results.append(await executor.execute(**{**self._kwargs, **kwargs}))
 
@@ -516,6 +476,7 @@ class PerGPU(ListExecutor):
         executor: `Executor` to be executed
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
+
     def __init__(self, executor: Executor, gpus: list = None, **kwargs) -> None:
         if gpus is None:
             gpus = [{"device": 0, "selection_variable": "CPU_VISIBLE_DEVICE"}]
@@ -549,16 +510,9 @@ class AccelerateLaunchExecutor(SingleCmdExecutor):
         *accelerate_argv: Accelerate's command line arguments list
         **kwargs: kwargs to be passed to the `pack.execute()`
     """
-    def __init__(
-            self,
-            pack: pack.BasePackage,
-            *accelerate_argv,
-            **kwargs
-    ) -> None:
-        super().__init__(
-            pack,
-            **kwargs
-        )
+
+    def __init__(self, pack: pack.BasePackage, *accelerate_argv, **kwargs) -> None:
+        super().__init__(pack, **kwargs)
         self.accelerate_argv = accelerate_argv
 
     def _argv(self, rank, **_) -> List:
@@ -610,19 +564,15 @@ class AccelerateLoopExecutor(Executor):
     PLACEHOLDER = _Placeholder()
 
     def __init__(
-            self,
-            executor: AccelerateLaunchExecutor,
-            ssh_exec: SSHExecutor = None,
-            **kwargs
+        self, executor: AccelerateLaunchExecutor, ssh_exec: SSHExecutor = None, **kwargs
     ) -> None:
         if not isinstance(ssh_exec, SSHExecutor):
-            raise ValueError(f"{self.__class__.__name__} only accepts"
-                             f" {SSHExecutor.__name__} as nested"
-                             f" {Executor.__name__}")
-        super().__init__(
-            ssh_exec,
-            **kwargs
-        )
+            raise ValueError(
+                f"{self.__class__.__name__} only accepts"
+                f" {SSHExecutor.__name__} as nested"
+                f" {Executor.__name__}"
+            )
+        super().__init__(ssh_exec, **kwargs)
         self.accelerate_exec = executor
         _exec = self
         while _exec:

--- a/milabench/multi.py
+++ b/milabench/multi.py
@@ -25,7 +25,6 @@ def planning_method(f):
     planning_methods[f.__name__] = f
 
 
-
 def make_execution_plan(pack, step=0, repeat=1):
     cfg = deepcopy(pack.config)
     plan = deepcopy(cfg["plan"])
@@ -45,7 +44,7 @@ def make_execution_plan(pack, step=0, repeat=1):
         exec_plan = PerGPU(exec_plan, devices)
 
     elif method == "njobs":
-        n = plan.pop('n')
+        n = plan.pop("n")
         exec_plan = NJobs(exec_plan, n, devices)
 
     else:
@@ -107,6 +106,7 @@ class MultiPackage:
 
                 except Exception as exc:
                     import traceback
+
                     traceback.print_exc()
                     await pack.message_error(exc)
 

--- a/milabench/pack.py
+++ b/milabench/pack.py
@@ -9,6 +9,7 @@ import json
 import os
 from argparse import Namespace as NS
 from sys import version_info as pyv
+import traceback
 from typing import Sequence
 
 from nox.sessions import Session, SessionRunner
@@ -129,7 +130,11 @@ class BasePackage:
         await send(
             BenchLogEntry(
                 event="error",
-                data={"type": type(exc).__name__, "message": str(exc)},
+                data={
+                    "type": type(exc).__name__, 
+                    "message": str(exc),
+                    "trace": traceback.format_exc(),
+                },
                 pack=self,
             )
         )

--- a/milabench/pack.py
+++ b/milabench/pack.py
@@ -131,7 +131,7 @@ class BasePackage:
             BenchLogEntry(
                 event="error",
                 data={
-                    "type": type(exc).__name__, 
+                    "type": type(exc).__name__,
                     "message": str(exc),
                     "trace": traceback.format_exc(),
                 },

--- a/milabench/validation/error.py
+++ b/milabench/validation/error.py
@@ -53,10 +53,10 @@ class Layer(ValidationLayer):
 
     def on_error(self, entry):
         error = self.errors[entry.tag]
-        
+
         if error.code == 0:
             error.code = 1
-        
+
         info = entry.data
         error.message = f'{info["type"]}: {info["message"]}'
         error.trace = info.get("trace")
@@ -87,7 +87,7 @@ class Layer(ValidationLayer):
                 else:
                     summary.add("* early stopped")
                     continue
-                
+
                 if error.trace:
                     tracebacks = error.trace.splitlines()
                 else:

--- a/milabench/vcs.py
+++ b/milabench/vcs.py
@@ -25,26 +25,25 @@ def retrieve_git_versions(tag="<tag>", commit="<commit>", date="<date>"):
     }
 
 
-
 def read_previous():
     info = ["<tag>", "<commit>", "<date>"]
-    
+
     with open(os.path.join(ROOT, "milabench", "_version.py"), "r") as file:
         for line in file.readlines():
-            
-            if 'tag' in line:
-                _, v = line.split('=')
+            if "tag" in line:
+                _, v = line.split("=")
                 info[0] = v.strip()
-                
-            if 'commit' in line:
-                _, v = line.split('=')
+
+            if "commit" in line:
+                _, v = line.split("=")
                 info[1] = v.strip()
 
-            if 'date' in line:
-                _, v = line.split('=')
+            if "date" in line:
+                _, v = line.split("=")
                 info[2] = v.strip()
-        
+
     return info
+
 
 def update_version_file():
     version_info = retrieve_git_versions(*read_previous())


### PR DESCRIPTION
Before:
* Python exception raised during Prepare & Install were printed but were not picked up by the error validation

Now:
* The error sets an error code so the error is picked up
* The error save the traceback so we can see the error more easily 
*  Prepare & Install show the full trace by default (since the exception is probably coming from the code)