### PR TITLE
Disable RWKV while docker issue is investigated

### DIFF
--- a/config/standard.yaml
+++ b/config/standard.yaml
@@ -118,7 +118,7 @@ dlrm:
   weight: 1.0
 
 rwkv:
-  enabled: true
+  enabled: false
   weight: 1.0
 
 ##################


### PR DESCRIPTION
```
rwkv [stderr] {'load_model': '', 'wandb': '', 'proj_dir': '/milabench/envs/proj/rwkv/', 'random_seed': 1234, 'data_file': '', 'data_type': 'dummy', 'vocab_size': 0, 'ctx_len': 128, 'epoch_steps': 1000, 'epoch_count': 20, 'epoch_begin': 0, 'epoch_save': 0, 'micro_bsz': 16, 'n_layer': 12, 'n_embd': 768, 'dim_att': 768, 'dim_ffn': 3072, 'pre_ffn': 0, 'head_qk': 0, 'tiny_att_dim': 0, 'tiny_att_layer': -999, 'lr_init': 0.0006, 'lr_final': 1e-05, 'warmup_steps': 0, 'beta1': 0.9, 'beta2': 0.99, 'adam_eps': 1e-08, 'grad_cp': 0, 'my_pile_version': 1, 'my_pile_stage': 0, 'my_pile_shift': -1, 'my_pile_edecay': 0, 'layerwise_lr': 1, 'ds_bucket_mb': 200, 'my_img_version': 0, 'my_img_size': 0, 'my_img_bit': 0, 'my_img_clip': 'x', 'my_img_clip_scale': 1, 'my_img_l1_scale': 0, 'my_img_encoder': 'x', 'my_sample_len': 0, 'my_ffn_shift': 1, 'my_att_shift': 1, 'my_pos_emb': 0, 'load_partial': 0, 'magic_prime': 0, 'my_qa_mask': 0, 'my_testing': '', 'logger': False, 'enable_checkpointing': False, 'default_root_dir': None, 'gradient_clip_val': 1.0, 'gradient_clip_algorithm': None, 'num_nodes': 1, 'num_processes': None, 'devices': '1', 'gpus': None, 'auto_select_gpus': None, 'tpu_cores': None, 'ipus': None, 'enable_progress_bar': False, 'overfit_batches': 0.0, 'track_grad_norm': -1, 'check_val_every_n_epoch': 100000000000000000000, 'fast_dev_run': False, 'accumulate_grad_batches': None, 'max_epochs': -1, 'min_epochs': None, 'max_steps': -1, 'min_steps': None, 'max_time': None, 'limit_train_batches': None, 'limit_val_batches': None, 'limit_test_batches': None, 'limit_predict_batches': None, 'val_check_interval': None, 'log_every_n_steps': 100000000000000000000, 'accelerator': 'gpu', 'strategy': 'ddp_find_unused_parameters_false', 'sync_batchnorm': False, 'precision': 'tf32', 'enable_model_summary': True, 'num_sanity_val_steps': 0, 'resume_from_checkpoint': None, 'profiler': None, 'benchmark': None, 'reload_dataloaders_every_n_epochs': 0, 'auto_lr_find': False, 'replace_sampler_ddp': False, 'detect_anomaly': False, 'auto_scale_batch_size': False, 'plugins': None, 'amp_backend': None, 'amp_level': None, 'move_metrics_to_cpu': False, 'multiple_trainloader_mode': 'max_size_cycle', 'inference_mode': True, 'my_timestamp': '2023-07-06-20-39-33', 'betas': (0.9, 0.99), 'real_bsz': 16, 'run_name': '0 ctx128 L12 D768'}
rwkv [stderr] 
rwkv [stderr] Building dummy data...
rwkv [stderr] Building token list...
rwkv [stderr] Data has 1620950 tokens, 13 vocab size.
rwkv [stdout] RWKV_MY_TESTING
rwkv [stderr] No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
rwkv [stderr] Using /milabench/envs/cache/torch_extensions/py310_cu118 as PyTorch extensions root...
rwkv [stderr] Creating extension directory /milabench/envs/cache/torch_extensions/py310_cu118/wkv_128...
rwkv [stderr] Detected CUDA files, patching ldflags
rwkv [stderr] Emitting ninja build file /milabench/envs/cache/torch_extensions/py310_cu118/wkv_128/build.ninja...
rwkv [stderr] ╭───────────────────── Traceback (most recent call last) ──────────────────────╮
rwkv [stderr] │ /milabench/envs/venv/torch/bin/voir:8 in <module>                            │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   5 from voir.cli import main                                                │
rwkv [stderr] │   6 if __name__ == '__main__':                                               │
rwkv [stderr] │   7 │   sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])     │
rwkv [stderr] │ ❱ 8 │   sys.exit(main())                                                     │
rwkv [stderr] │   9                                                                          │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/voir/cli.py:30 in    │
rwkv [stderr] │ main                                                                         │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   27 │   instruments.extend(collect_contrib_instruments())                   │
rwkv [stderr] │   28 │                                                                       │
rwkv [stderr] │   29 │   ov = Overseer(instruments=instruments, logfile=int(os.environ.get(" │
rwkv [stderr] │ ❱ 30 │   ov(sys.argv[1:] if argv is None else argv)                          │
rwkv [stderr] │   31                                                                         │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/voir/overseer.py:148 │
rwkv [stderr] │ in __call__                                                                  │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   145 │   def __call__(self, *args, **kwargs):                               │
rwkv [stderr] │   146 │   │   token = current_overseer.set(self)                             │
rwkv [stderr] │   147 │   │   try:                                                           │
rwkv [stderr] │ ❱ 148 │   │   │   super().__call__(*args, **kwargs)                          │
rwkv [stderr] │   149 │   │   except BaseException as e:                                     │
rwkv [stderr] │   150 │   │   │   self.log(                                                  │
rwkv [stderr] │   151 │   │   │   │   {                                                      │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/voir/phase.py:326 in │
rwkv [stderr] │ __call__                                                                     │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   323 │   def __call__(self, *args, **kwargs):                               │
rwkv [stderr] │   324 │   │   with given() as gv:                                            │
rwkv [stderr] │   325 │   │   │   self.given = gv                                            │
rwkv [stderr] │ ❱ 326 │   │   │   super().__call__(*args, **kwargs)                          │
rwkv [stderr] │   327 │   │   │   self._dump_queue()                                         │
rwkv [stderr] │   328                                                                        │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/voir/phase.py:268 in │
rwkv [stderr] │ __call__                                                                     │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   265 │   │   try:                                                           │
rwkv [stderr] │   266 │   │   │   for req in self._to_require:                               │
rwkv [stderr] │   267 │   │   │   │   self.require(req)                                      │
rwkv [stderr] │ ❱ 268 │   │   │   self.run(*args, **kwargs)                                  │
rwkv [stderr] │   269 │   │   except StopProgram as stp:                                     │
rwkv [stderr] │   270 │   │   │   self.on_stop(*stp.args)                                    │
rwkv [stderr] │   271 │   │   │   pass                                                       │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/voir/overseer.py:143 │
rwkv [stderr] │ in run                                                                       │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   140 │   │                                                                  │
rwkv [stderr] │   141 │   │   with self.run_phase(self.phases.run_script) as set_value:      │
rwkv [stderr] │   142 │   │   │   sys.argv = [script, *argv]                                 │
rwkv [stderr] │ ❱ 143 │   │   │   set_value(func())                                          │
rwkv [stderr] │   144 │                                                                      │
rwkv [stderr] │   145 │   def __call__(self, *args, **kwargs):                               │
rwkv [stderr] │   146 │   │   token = current_overseer.set(self)                             │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/voir/overseer.py:195 │
rwkv [stderr] │ in <lambda>                                                                  │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   192 │   │   glb["__spec__"] = ModuleSpec(name=module_name, loader=None)    │
rwkv [stderr] │   193 │   sys.modules["__main__"] = mod                                      │
rwkv [stderr] │   194 │   exec(prep, glb, glb)                                               │
rwkv [stderr] │ ❱ 195 │   return lambda: exec(mainsection, glb, glb)                         │
rwkv [stderr] │   196                                                                        │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/milabench/benchmarks/rwkv/rwkv-v4neo/train.py:290 in <module>     │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   287 │   │   from src.model_img import RWKV_IMG                             │
rwkv [stderr] │   288 │   │   model = RWKV_IMG(args)                                         │
rwkv [stderr] │   289 │   else:                                                              │
rwkv [stderr] │ ❱ 290 │   │   from src.model import RWKV                                     │
rwkv [stderr] │   291 │   │   model = RWKV(args)                                             │
rwkv [stderr] │   292 │                                                                      │
rwkv [stderr] │   293 │   # if len(args.load_model) == 0 or args.my_pile_stage == 1:  # shal │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/milabench/benchmarks/rwkv/rwkv-v4neo/src/model.py:80 in <module>  │
rwkv [stderr] │                                                                              │
rwkv [stderr] │    77 │   │   │   gu = torch.sum(gu, dim=0)                                  │
rwkv [stderr] │    78 │   │   │   return (None, None, None, gw, gu, gk, gv)                  │
rwkv [stderr] │    79 else:                                                                  │
rwkv [stderr] │ ❱  80 │   wkv_cuda = load(name=f"wkv_{T_MAX}", sources=["cuda/wkv_op.cpp", " │
rwkv [stderr] │    81 │   class WKV(torch.autograd.Function):                                │
rwkv [stderr] │    82 │   │   @staticmethod                                                  │
rwkv [stderr] │    83 │   │   def forward(ctx, B, T, C, w, u, k, v):                         │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/torch/utils/cpp_exte │
rwkv [stderr] │ nsion.py:1284 in load                                                        │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   1281 │   │   ...     extra_cflags=['-O2'],                                 │
rwkv [stderr] │   1282 │   │   ...     verbose=True)                                         │
rwkv [stderr] │   1283 │   '''                                                               │
rwkv [stderr] │ ❱ 1284 │   return _jit_compile(                                              │
rwkv [stderr] │   1285 │   │   name,                                                         │
rwkv [stderr] │   1286 │   │   [sources] if isinstance(sources, str) else sources,           │
rwkv [stderr] │   1287 │   │   extra_cflags,                                                 │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/torch/utils/cpp_exte │
rwkv [stderr] │ nsion.py:1509 in _jit_compile                                                │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   1506 │   │   │   │   │   │                                                 │
rwkv [stderr] │   1507 │   │   │   │   │   │   sources = list(hipified_sources)              │
rwkv [stderr] │   1508 │   │   │   │   │                                                     │
rwkv [stderr] │ ❱ 1509 │   │   │   │   │   _write_ninja_file_and_build_library(              │
rwkv [stderr] │   1510 │   │   │   │   │   │   name=name,                                    │
rwkv [stderr] │   1511 │   │   │   │   │   │   sources=sources,                              │
rwkv [stderr] │   1512 │   │   │   │   │   │   extra_cflags=extra_cflags or [],              │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/torch/utils/cpp_exte │
rwkv [stderr] │ nsion.py:1611 in _write_ninja_file_and_build_library                         │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   1608 │   │   print(f'Emitting ninja build file {build_file_path}...', file │
rwkv [stderr] │   1609 │   # NOTE: Emitting a new ninja build file does not cause re-compila │
rwkv [stderr] │   1610 │   # the sources did not change, so it's ok to re-emit (and it's fas │
rwkv [stderr] │ ❱ 1611 │   _write_ninja_file_to_build_library(                               │
rwkv [stderr] │   1612 │   │   path=build_file_path,                                         │
rwkv [stderr] │   1613 │   │   name=name,                                                    │
rwkv [stderr] │   1614 │   │   sources=sources,                                              │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/torch/utils/cpp_exte │
rwkv [stderr] │ nsion.py:2007 in _write_ninja_file_to_build_library                          │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   2004 │   │   cuda_flags += extra_cuda_cflags                               │
rwkv [stderr] │   2005 │   │   cuda_flags += _get_rocm_arch_flags(cuda_flags)                │
rwkv [stderr] │   2006 │   elif with_cuda:                                                   │
rwkv [stderr] │ ❱ 2007 │   │   cuda_flags = common_cflags + COMMON_NVCC_FLAGS + _get_cuda_ar │
rwkv [stderr] │   2008 │   │   if IS_WINDOWS:                                                │
rwkv [stderr] │   2009 │   │   │   for flag in COMMON_MSVC_FLAGS:                            │
rwkv [stderr] │   2010 │   │   │   │   cuda_flags = ['-Xcompiler', flag] + cuda_flags        │
rwkv [stderr] │                                                                              │
rwkv [stderr] │ /milabench/envs/venv/torch/lib/python3.10/site-packages/torch/utils/cpp_exte │
rwkv [stderr] │ nsion.py:1773 in _get_cuda_arch_flags                                        │
rwkv [stderr] │                                                                              │
rwkv [stderr] │   1770 │   │   │   if arch not in arch_list:                                 │
rwkv [stderr] │   1771 │   │   │   │   arch_list.append(arch)                                │
rwkv [stderr] │   1772 │   │   arch_list = sorted(arch_list)                                 │
rwkv [stderr] │ ❱ 1773 │   │   arch_list[-1] += '+PTX'                                       │
rwkv [stderr] │   1774 │   else:                                                             │
rwkv [stderr] │   1775 │   │   # Deal with lists that are ' ' separated (only deal with ';'  │
rwkv [stderr] │   1776 │   │   _arch_list = _arch_list.replace(' ', ';')                     │
rwkv [stderr] ╰──────────────────────────────────────────────────────────────────────────────╯
rwkv [stderr] IndexError: list index out of range
rwkv [stdout] ================================================================================
rwkv [stdout] Done
rwkv [end] /milabench/milabench/benchmarks/rwkv/prepare.py --data_type dummy --ctx_len 128 --epoch_steps 1000 --epoch_count 20 --epoch_begin 0 --epoch_save 0 --micro_bsz 16 --n_layer 12 --n_embd 768 --pre_ffn 0 --head_qk 0 --lr_init 6e-4 --lr_final 1e-5 --warmup_steps 0 --beta1 0.9 --beta2 0.99 --adam_eps 1e-8 --accelerator gpu --devices 1 --precision tf32 --strategy ddp_find_unused_parameters_false --grad_cp 0 --random_seed 1234 --enable_progress_bar False [at 2023-07-06 20:39:35.711625]
```