### PR TITLE
Add flops benchmark

### DIFF
--- a/benchmarks/flops/benchfile.py
+++ b/benchmarks/flops/benchfile.py
@@ -1,0 +1,10 @@
+from milabench.pack import Package
+
+
+class FlopsBenchmarch(Package):
+    base_requirements = "requirements.in"
+    prepare_script = "prepare.py"
+    main_script = "main.py"
+
+
+__pack__ = FlopsBenchmarch

--- a/benchmarks/flops/main.py
+++ b/benchmarks/flops/main.py
@@ -1,0 +1,109 @@
+from argparse import ArgumentParser
+import json
+import time
+import sys
+
+import torch
+
+from voir.smuggle import SmuggleWriter
+from voir.instruments.gpu import get_gpu_info
+from voir.instruments.utils import Monitor
+
+KILO = 1e3
+MEGA = 1e6
+GIGA = 1e9
+TERA = 1e12
+EXA = 1e18
+
+
+def f(N, m=5000000, n=256, unit=TERA, dtype=torch.float32):
+    torch.cuda.empty_cache()
+    a = torch.eye(n, dtype=dtype, device="cuda:0")
+    x = torch.randn((m, n), dtype=dtype, device="cuda:0")
+    y = torch.zeros_like(x)
+
+    torch.cuda.synchronize()
+    ts = -time.time()
+    
+    for _ in range(N):
+        # No allocation in main loop using dual-out strategy
+        y = torch.mm(x, a, out=y)
+        x = torch.mm(y, a, out=x)
+    
+    torch.cuda.synchronize()
+    ts += time.time()
+    torch.cuda.empty_cache()
+    F = N * (2 * m * n * n + 2 * m * n * n)
+    return F / ts / unit
+
+
+
+def setupvoir():
+    data_file = SmuggleWriter(sys.stdout)
+    def log(data):
+        if data_file is not None:
+            print(json.dumps(data), file=data_file)
+        
+    def monitor_fn():
+        data = {
+            gpu["device"]: {
+                "memory": [
+                    gpu["memory"]["used"], 
+                    gpu["memory"]["total"],
+                ],
+                "load": gpu["utilization"]["compute"],
+                "temperature": gpu["temperature"],
+            }
+            for gpu in get_gpu_info()["gpus"].values()
+        }
+        log({"task": "main", "gpudata": data})
+        
+    monitor = Monitor(3, monitor_fn)
+    monitor.start()
+    return log, monitor
+
+    
+
+def main():
+    dtypes = {
+        'bf16': torch.bfloat16,
+        'fp16': torch.float16,
+        'fp32': torch.float32,
+    }
+        
+    parser = ArgumentParser()
+    parser.add_argument('--repeat', type=int, default=100)
+    parser.add_argument('--m', type=int, default=256)
+    parser.add_argument('--n', type=int, default=256)
+    parser.add_argument('--dtype', type=str, default='fp32', choices=dtypes.keys())
+    parser.add_argument('--unit', default='TERA')
+    parser.add_argument('--tf32', action='store_true', default=False)
+    
+    args = parser.parse_args()
+    
+    torch.backends.cuda.matmul.allow_tf32 = False
+    if args.tf32:
+        torch.backends.cuda.matmul.allow_tf32 = True
+    
+    log, monitor = setupvoir()
+
+    flops = f(
+        args.repeat,
+        args.m,
+        args.n,
+        args.unit,
+        dtypes[args.dtype]
+    )
+
+    log({
+        "task": "train",
+        "rate": flops,
+        "units": "Tflops"
+    })
+    
+    monitor.stop()
+    
+
+
+
+

--- a/benchmarks/flops/requirements.in
+++ b/benchmarks/flops/requirements.in
@@ -1,0 +1,4 @@
+torch
+torchvision
+tqdm
+voir>=0.2.9,<0.3

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -23,6 +23,16 @@ _torchvision:
     --no-stdout: true
     --epochs: 50
 
+_flops:
+  inherits: _defaults
+  definition: ../benchmarks/flops
+  group: torchvision
+  install_group: torch
+  plan:
+    method: per_gpu
+  argv:
+    --repeat: 100
+
 _hf:
   inherits: _defaults
   definition: ../benchmarks/huggingface
@@ -85,6 +95,41 @@ _accelerate_opt:
   gradient_accumulation_steps: 1
   use_deepspeed: true
   num_machines: 1
+
+
+fp16:
+  inherits: _flops
+ 
+  argv:
+    --m: 8192
+    --n: 8192
+    --dtype: fp16
+
+bf16:
+  inherits: _flops
+ 
+  argv:
+    --m: 8192
+    --n: 8192
+    --dtype: bf16
+
+tf32:
+  inherits: _flops
+ 
+  argv:
+    --m: 8192
+    --n: 8192
+    --dtype: fp32
+    --tf32: true
+
+fp32:
+  inherits: _flops
+ 
+  argv:
+    --m: 8192
+    --n: 8192
+    --dtype: fp32
+  
 
 resnet50:
   inherits: _torchvision

--- a/config/standard.yaml
+++ b/config/standard.yaml
@@ -121,6 +121,22 @@ rwkv:
   enabled: true
   weight: 1.0
 
+fp16:
+  enabled: true
+  weight: 0.0
+
+bf16:
+  enabled: true
+  weight: 0.0
+
+tf322:
+  enabled: true
+  weight: 0.0
+
+fp32:
+  enabled: true
+  weight: 0.0
+
 ##################
 # Disabled tests #
 ##################


### PR DESCRIPTION
Used as sanity checks & diagnostic bottlenecks.
New hardware might not be used efficiently by today's models because they were built for different hardware.
Matrix mult is everywhere in AI, this should make us see if the hardware is slow or simply not used efficiently by models.