### PR TITLE
Fix rlhf on trl v0.11.0

### DIFF
--- a/benchmarks/rlhf/main.py
+++ b/benchmarks/rlhf/main.py
@@ -13,7 +13,7 @@ from transformers import (
 
 from trl import ModelConfig
 from trl.trainer.ppov2_trainer import PPOv2Config, PPOv2Trainer
-from trl.trainer.utils import SIMPLE_QUERY_CHAT_TEMPLATE
+from trl.trainer.utils import SIMPLE_CHAT_TEMPLATE
 
 
 class PPOv2TrainerIntrumented(PPOv2Trainer):
@@ -62,7 +62,7 @@ def main():
     )
     tokenizer.add_special_tokens({"pad_token": "[PAD]"})
     if tokenizer.chat_template is None:
-        tokenizer.chat_template = SIMPLE_QUERY_CHAT_TEMPLATE
+        tokenizer.chat_template = SIMPLE_CHAT_TEMPLATE
     value_model = AutoModelForSequenceClassification.from_pretrained(
         config.reward_model_path, trust_remote_code=model_config.trust_remote_code, num_labels=1
     )

--- a/benchmarks/rlhf/prepare.py
+++ b/benchmarks/rlhf/prepare.py
@@ -11,7 +11,7 @@ from transformers import (
 from datasets import load_dataset
 from trl import ModelConfig
 from trl.trainer.ppov2_trainer import PPOv2Config
-from trl.trainer.utils import SIMPLE_QUERY_CHAT_TEMPLATE
+from trl.trainer.utils import SIMPLE_CHAT_TEMPLATE
 
 
 if __name__ == "__main__":
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     tokenizer.add_special_tokens({"pad_token": "[PAD]"})
 
     if tokenizer.chat_template is None:
-        tokenizer.chat_template = SIMPLE_QUERY_CHAT_TEMPLATE
+        tokenizer.chat_template = SIMPLE_CHAT_TEMPLATE
     
     value_model = AutoModelForSequenceClassification.from_pretrained(
         config.reward_model_path, 


### PR DESCRIPTION
Tested on:

```
remote [stdout] =================                                                                                                                                    
remote [stdout] Benchmark results                                                                                                                                    
remote [stdout] =================                                                                                                                                    
remote [stdout]                                                                                                                                                      
remote [stdout] System                                                                                                                                               
remote [stdout] ------                                                                                                                                               
remote [stdout] cpu:      AMD EPYC 7543 32-Core Processor                                                                                                            
remote [stdout] n_cpu:    64                                                                                                                                         
remote [stdout] product:  NVIDIA A100-SXM4-80GB                                                                                                                      
remote [stdout] n_gpu:    1                                                                                                                                          
remote [stdout] memory:   81920.0                                                                                                                                    
remote [stdout]                                                                                                                                                      
remote [stdout] Breakdown                                                                                                                                            
remote [stdout] ---------                                                                                                                                            
remote [stdout] bench       | fail |   n | ngpu |       perf |   sem% |   std% | peak_memory |      score | weight                                                   
remote [stdout] rlhf-single |    0 |   1 |    1 |    2589.65 |   0.5% |   4.2% |       12455 |    2589.65 |   1.00                                                   
remote [stdout]                                                                                                                                                      
remote [stdout] Scores                                                                                                                                               
remote [stdout] ------                                                                                                                                               
remote [stdout] Failure rate:       0.00% (PASS)                                                                                                                     
remote [stdout] Score:            2589.65                                                                                                                            
```

```
=================
Benchmark results
=================

System
------
cpu:      AMD EPYC 7543 32-Core Processor
n_cpu:    64
product:  NVIDIA A100-SXM4-80GB
n_gpu:    4
memory:   81920.0

Breakdown
---------
bench     | fail |   n | ngpu |       perf |   sem% |   std% | peak_memory |      score | weight
rlhf-gpus |    0 |   1 |    4 |    7179.24 |   0.4% |   2.9% |       21351 |    7179.24 |   1.00

Scores
------
Failure rate:       0.00% (PASS)
Score:            7179.24
```