### PR TITLE
Fix early stop returning errcode -15

### DIFF
--- a/milabench/commands/executors.py
+++ b/milabench/commands/executors.py
@@ -139,6 +139,7 @@ async def execute_command(
                     # kill the underlying process which should force the coro to 
                     # return on next wait
                     pack = packs[timedout]
+                    await pack.send(event="stop", data=None)
                     await force_terminate_now(pack, max_delay)
 
                 # Grace period

--- a/tests/config/early_stop.yaml
+++ b/tests/config/early_stop.yaml
@@ -1,0 +1,20 @@
+_defaults:
+  max_duration: 1
+  voir:
+    options:
+      stop: 10
+      interval: "1s"
+
+benchio:
+  inherits: _defaults
+  definition: ../yoshua-benchio
+  plan:
+    method: njobs
+    n: 1
+  tags:
+    - monogpu
+
+  argv:
+    --sleep: 60
+    --start: 1
+    --end: 11

--- a/tests/yoshua-benchio/main.py
+++ b/tests/yoshua-benchio/main.py
@@ -30,9 +30,6 @@ def main():
 
     args = parser.parse_args()
 
-    if args.sleep is not None:
-        time.sleep(args.sleep)
-
     data = [[[i]] for i in range(args.start, args.end)]
 
     if args.bad:
@@ -40,6 +37,10 @@ def main():
 
     for [[x]] in voir.iterate("train", data, True):
         give(loss=1 / x)
+    give(rate=args.end - args.start)
+
+    if args.sleep is not None:
+        time.sleep(args.sleep)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Current log :

```
benchio.0 [message] Terminating process because it ran for longer than 1 seconds.
benchio.0[end (-15)] 'milabench/bin/voir' --config /tmp/extra/benchio/voirconf-benchio.0-384a97a8bb2d5d89323fc897d5a5d82e.json milabench/tests/yoshua-benchio/main.py --sleep 60 --start 1 --end 11 [at 2024-11-25 15:51:09.910958] benchio.0
=========
  * Error codes = -15
  * No traceback info about the error
```

instead of

```
benchio.0 [message] Terminating process because it ran for longer than 1 seconds.
benchio.0 [end] 'milabench/bin/voir' --config /tmp/extra/benchio/voirconf-benchio.0-384a97a8bb2d5d89323fc897d5a5d82e.json milabench/tests/yoshua-benchio/main.py --sleep 60 --start 1 --end 11 [at 2024-11-25 16:00:30.277804] benchio.0
=========
  * early stopped
```