### PR TITLE
fix(purejaxrl): revert dqn benchmark to CartPole-v1

### DIFF
--- a/benchmarks/purejaxrl/dqn.py
+++ b/benchmarks/purejaxrl/dqn.py
@@ -2,21 +2,18 @@
 PureJaxRL version of CleanRL's DQN: https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/dqn_jax.py
 """
 from dataclasses import dataclass
-import time
 
+import chex
+import flashbax as fbx
+import flax
+import flax.linen as nn
+import gymnax
 import jax
 import jax.numpy as jnp
-import chex
-import flax
 import optax
-import flax.linen as nn
-from flax.training.train_state import TrainState
-import gymnax
-from gymnax.wrappers.purerl import FlattenObservationWrapper, LogWrapper
-import flashbax as fbx
-
 from benchmate.metrics import give_push
-
+from flax.training.train_state import TrainState
+from gymnax.wrappers.purerl import FlattenObservationWrapper, LogWrapper
 
 
 class QNetwork(nn.Module):
@@ -51,8 +48,8 @@ class CustomTrainState(TrainState):
 def make_train(config):
     config["NUM_UPDATES"] = config["TOTAL_TIMESTEPS"] // config["NUM_ENVS"]
 
-    from benchmate.timings import StepTimer
     from benchmate.jaxmem import memory_peak_fetcher
+    from benchmate.timings import StepTimer
     step_timer = StepTimer(give_push())
     fetch_memory_peak = memory_peak_fetcher()
 
@@ -246,7 +243,6 @@ def make_train(config):
                 loss = metrics["loss"].block_until_ready().item()
                 delta = metrics["timesteps"] - step_timer.timesteps
                 step_timer.timesteps = metrics["timesteps"]
-                
                 step_timer.step(delta.item())
                 step_timer.log(returns=returns, loss=loss)
                 step_timer.log(memory_peak=fetch_memory_peak(), units="MiB")
@@ -315,15 +311,30 @@ def make_train(config):
 # dqn.D0 [stdout]   pool_bytes: 60832.359375 MiB
 # dqn.D0 [stdout]   peak_pool_bytes: 60832.359375 MiB
 
+# When scaling `num_envs`, take care to not change the number of
+# training steps. For example, a training interval of 10 is the
+# modulod with the timestep to signal training. If there are 11
+# parallel environements, the modulo will not do what you might
+# expect. More than 110 steps will run: [11, 22, 33, 44, ..., 110].
+# Similarly, `target_update_interval` of 500 can also be skipped.
+#
+# When num_envs exceeds 10 environments, the training_interval is
+# no longer respected.
+#
+# To see num_env(1) defaults, see the cleanrl implementation at:
+# https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/dqn.py
+
 
 @dataclass
 class Arguments:
+    benchmark: str = 'dqn'
     num_envs: int = 10                  # No impact on memory
     buffer_size: int = 10000            # No impact on memory
     buffer_batch_size: int = 128
-    total_timesteps: int = 100_000      # No impact on memory
+    total_timesteps: int = 500000       # No impact on memory
     epsilon_start: float =  1.0
     epsilon_finish: float = 0.05
+    exploration_fraction: float = 0.5
     epsilon_anneal_time: int = 25e4
     target_update_interval: int = 500
     lr: float = 2.5e-4
@@ -338,11 +349,29 @@ class Arguments:
     project: str = ""
     dtype: str = "fp32"
 
+    def __post_init__(self):
+        if self.exploration_fraction * self.total_timesteps != self.epsilon_anneal_time:
+            raise ValueError(f"{self.epsilon_anneal_time=} must be equal to exploration_fraction * total_timesteps")
+        if self.target_update_interval % self.num_envs:
+            raise ValueError(f"{self.target_update_interval=} must be divisible by {self.num_envs=}")
+        if self.learning_starts > self.total_timesteps:
+            raise ValueError(f"{self.learning_starts=} exceeds {self.total_timesteps=}")
+        if self.epsilon_anneal_time > self.total_timesteps:
+            raise ValueError(f"{self.epsilon_anneal_time=} exceeds {self.total_timesteps=}")
+        if self.env_name.endswith('-MinAtar'):
+            # The DQN algorithm is the same for DQN-Atari, but the implementation
+            # differs from the original 2015 DQN paper in multiple ways:
+            #   1. Hyperparameters (larger RB)
+            #   2. Q-network architecture (CNN)
+            #   3. Different model optimizer (Adam)
+            #   4. Environment initialization (noop frames)
+            # To add support, port https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/dqn_atari.py
+            raise ValueError("Atari environments are not supported by this pipeline.")
+
 
 def add_dqn_command(subparser):
     parser = subparser.add_parser('dqn', help='RL dqn benchmark')
     parser.add_arguments(Arguments)
-
 
 
 _DTYPE_MAP = {
@@ -355,6 +384,9 @@ _DTYPE_MAP = {
 def main(args: Arguments = None):
     if args is None:
         args = Arguments()
+    else:
+        # Arguments.__post_init__() is not evaluated by main.py
+        args = Arguments(**vars(args))
 
     config = {
         "NUM_ENVS": args.num_envs,

--- a/config/training.yaml
+++ b/config/training.yaml
@@ -33,7 +33,7 @@ _torchvision_ddp:
     --num-workers: "auto({n_worker}, 8)"
     --loader: pytorch
     --data: "{milabench_data}/FakeImageNet"
-  
+
   requires_capabilities:
     - "gpu['count'] > 1"
 
@@ -44,13 +44,13 @@ _flops:
   install_group: torch
   plan:
     method: per_gpu
-  
+
   tags:
     - diagnostic
     - flops
     - monogpu
     - nobatch
-  
+
   argv:
     --number: 10
     --repeat: 90
@@ -85,7 +85,7 @@ _timm:
     --dataset: "FakeImageNet"
     --workers: "auto({n_worker}, 8)"
     --batch-size: "auto_batch(128)"
-  
+
 _accelerate_opt:
   inherits: _defaults
   tags:
@@ -100,7 +100,7 @@ _accelerate_opt:
   plan:
     method: njobs
     n: 1
-  
+
   # Accelerate
   # accelerate:
   #   - --mixed_precision=bf16
@@ -144,7 +144,7 @@ fp16:
 
 bf16:
   inherits: _flops
- 
+
   argv:
     --m: 8192
     --n: 8192
@@ -152,7 +152,7 @@ bf16:
 
 tf32:
   inherits: _flops
- 
+
   argv:
     --m: 8192
     --n: 8192
@@ -161,18 +161,18 @@ tf32:
 
 fp32:
   inherits: _flops
- 
+
   argv:
     --m: 8192
     --n: 8192
-    --dtype: fp32  
+    --dtype: fp32
 
 resnet50:
   voir:
     options:
       stop: 60
       gpu_poll: 0.1
-    
+
   inherits: _torchvision
   tags:
     - vision
@@ -180,14 +180,14 @@ resnet50:
     - convnet
     - resnet
     - monogpu
-  
+
   argv:
     --model: resnet50
     --batch-size: "auto_batch(256)"
     --num-workers: "auto({n_worker}, 8)"
     --loader: pytorch
     --optim: channel_last
-  
+
 resnet50-noio:
   inherits: _torchvision
   voir:
@@ -202,7 +202,7 @@ resnet50-noio:
     - resnet
     - noio
     - monogpu
-  
+
   argv:
     --model: resnet50
     --batch-size: "auto_batch(256)"
@@ -217,7 +217,7 @@ resnet152-ddp-gpus:
     - convnet
     - resnet
     - multigpu
-  
+
   voir:
     options:
       stop: 60
@@ -484,7 +484,7 @@ dinov2-giant-single:
   tags:
     - monogpu
   argv:
-    - --config-file 
+    - --config-file
     - "{benchmark_folder}/src/dinov2/configs/train/vitg14.yaml"
     # THOSE NEED TO BE LAST
     - train.dataset_path=ImageNet:split=TRAIN:root={milabench_data}/FakeImageNet:extra={milabench_data}/FakeImageNet
@@ -605,7 +605,7 @@ llm-lora-ddp-nodes:
   plan:
     method: njobs
     n: 1
-  
+
   url: https://huggingface.co/meta-llama/Llama-3.1-8B
   argv:
     # "{milabench_code}/bench/lora_finetune_distributed.py": true
@@ -638,7 +638,7 @@ llm-lora-mp-gpus:
 
   requires_capabilities:
     - "gpu['count'] > 1"
-  
+
   argv:
     # "{milabench_code}/bench/lora_finetune_distributed.py": true
     bench/lora_finetune_distributed.py: true
@@ -654,7 +654,7 @@ llm-lora-mp-gpus:
     batch_size=auto_batch(8): true
     gradient_accumulation_steps=1: true
     device={device_name}: true
-  
+
 llm-full-mp-gpus:
   voir:
     options:
@@ -686,7 +686,7 @@ llm-full-mp-gpus:
     batch_size=auto_batch(2): true
     gradient_accumulation_steps=1: true
     device={device_name}: true
-  
+
 llm-full-mp-nodes:
   url: https://huggingface.co/meta-llama/Llama-3.1-70B
   tags:
@@ -712,7 +712,7 @@ llm-full-mp-nodes:
     batch_size=auto_batch(2): true
     gradient_accumulation_steps=1: true
     device={device_name}: true
-  
+
   num_machines: 2
   requires_capabilities:
     - "len(nodes) >= ${..num_machines}"
@@ -733,12 +733,8 @@ dqn:
   inherits: _purejaxrl
   argv:
     dqn: true
-    --num_envs: auto({cpu_per_gpu}, 128)
-    --buffer_size: 131072
-    --buffer_batch_size: 65536
-    --env_name: SpaceInvaders-MinAtar
-    --training_interval: 10
-    --total_timesteps: 2000000
+    --num_envs: 10
+    --env_name: CartPole-v1
 
 ppo:
   inherits: _purejaxrl
@@ -767,7 +763,7 @@ pna:
   argv:
     --model: 'PNA'
     --num-samples: 100000
-    --batch-size: "auto_batch(4096)" 
+    --batch-size: "auto_batch(4096)"
     --num-workers: "auto({n_worker}, 0)"
     --root: "{milabench_data}"
 
@@ -857,7 +853,7 @@ _rlhf:
     --dtype: bfloat16
     --dataset-name: "trl-internal-testing/descriptiveness-sentiment-trl-style"
     --dataset_train_split: "descriptiveness"
-  
+
 rlhf-single:
   inherits: _rlhf
   tags:
@@ -909,7 +905,7 @@ cleanrljax:
     - jax
   plan:
     method: per_gpu
-  
+
   # args.batch_size     = int(args.num_envs * args.num_steps)
   # args.minibatch_size = int(args.batch_size // args.num_minibatches)
   # args.num_iterations = args.total_timesteps // args.batch_size


### PR DESCRIPTION
### Context

We ran an agentic coding optimization session last week where agents were tasked with optimizing this pipeline. The agents found optimizations, but after closer inspection, the pipeline was found to be misconfigured.

The `dqn.py` pipeline in `purejaxrl` is based on a "classic" DQN that works with low level features like cart position, velocity, angle, and angular velocity ([Link to implementation](https://github.com/RobertTLange/gymnax/blob/main/gymnax/environments/classic_control/cartpole.py)). 

This `dqn.py` pipeline was ported from `cleanrl` in [cleanrl/dqn.py](https://github.com/vwxyzjn/cleanrl/blob/fe8d8a03c41a7ef5b523e2e354bd01c363e786bb/cleanrl/dqn.py).

The environment change from the default `CartPole-v1` to `SpaceInvader-MinAtar`was intended to increase GPU load through the larger observation space. It had the effect, but more work is needed for the pipeline to be representative of DQN Atari.

### Issue(s)

The `cleanrl` repo also implements the DQN algorithm adapted for Atari: [cleanrl/dqn_atari.py](https://github.com/vwxyzjn/cleanrl/blob/fe8d8a03c41a7ef5b523e2e354bd01c363e786bb/cleanrl/dqn_atari.py). There was no port of `dqn_atari.py` to `purejaxrl` - so no support for the *-MinAtar environments in DQN. This suggests to me that the `purejaxrl` maintainer expects that PPO would be used for Atari environments.

The DQN algorithm is the same for DQN-Atari, but the implementation differs from the original DQN algorithim in multiple ways:

1. Hyperparameters (larger RB)
2. Q-network architecture (CNN)
3. Different model optimizer (Adam)
4. Environment initialization (noop frames)

While running atari frame observations in a (smaller) vector observation space will run, it won't learn optimally and is easily misleading.

To add support for DQN-Atari, it may be possible to port https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/dqn_atari.py - this may take one or two days.

### Fix

Revert to intended environment `cartpole-v1` for the dqn benchmark. I've also added some argument validation to avoid misconfiguration in the future.

`total_timesteps` differed from the cleanrl implementation and restored to 500k.

I ran the benchmark through the three supported `num_env` values:

**num_env = 1**
<img width="1484" height="880" alt="image" src="https://github.com/user-attachments/assets/deb7c9db-5e3d-4633-8545-75048a7ecbe6" />

**num_env = 5**
<img width="1484" height="880" alt="image" src="https://github.com/user-attachments/assets/8d77df12-e750-4361-8196-3b416e5c47a1" />

**num_env = 10**
<img width="1484" height="880" alt="image" src="https://github.com/user-attachments/assets/fcaa016d-ec36-4b14-9c13-4f838cf91744" />

These align well with cleanrl's results https://docs.cleanrl.dev/rl-algorithms/dqn/#experiment-results_1

<img width="4256" height="2656" alt="image" src="https://github.com/user-attachments/assets/f05347d3-9616-450e-a1ea-77355fe9b077" />

